### PR TITLE
[WIP] Implement a MixMemoryManager to physically separate Index and Data Cache

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -153,7 +153,12 @@ object FiberCache {
   //  For test purpose :convert Array[Byte] to FiberCache
   private[oap] def apply(data: Array[Byte]): FiberCache = {
     val memoryBlockHolder =
-      DataMemoryBlockHolder(data, Platform.BYTE_ARRAY_OFFSET, data.length, data.length)
+      MemoryBlockHolder(
+        CacheEnum.GENERAL,
+        data,
+        Platform.BYTE_ARRAY_OFFSET,
+        data.length,
+        data.length)
     FiberCache(memoryBlockHolder)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCache.scala
@@ -153,7 +153,7 @@ object FiberCache {
   //  For test purpose :convert Array[Byte] to FiberCache
   private[oap] def apply(data: Array[Byte]): FiberCache = {
     val memoryBlockHolder =
-      MemoryBlockHolder(data, Platform.BYTE_ARRAY_OFFSET, data.length, data.length)
+      DataMemoryBlockHolder(data, Platform.BYTE_ARRAY_OFFSET, data.length, data.length)
     FiberCache(memoryBlockHolder)
   }
 }

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManager.scala
@@ -104,9 +104,10 @@ private[sql] class FiberCacheManager(
   private val cacheBackend: OapCache = {
     val cacheName = sparkEnv.conf.get("spark.oap.cache.strategy", DEFAULT_CACHE_STRATEGY)
     if (cacheName.equals(GUAVA_CACHE)) {
-      new GuavaOapCache(memoryManager.cacheMemory, memoryManager.cacheGuardianMemory,
-        sparkEnv.conf.getDouble(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key, OapConf
-          .OAP_DATAFIBER_USE_FIBERCACHE_RATIO.defaultValue.get))
+      new GuavaOapCache(
+        memoryManager.dataCacheMemory,
+        memoryManager.indexCacheMemory,
+        memoryManager.cacheGuardianMemory)
     } else if (cacheName.equals(SIMPLE_CACHE)) {
       new SimpleOapCache()
     } else {

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/oap/filecache/OapCache.scala
@@ -117,17 +117,19 @@ class SimpleOapCache extends OapCache with Logging {
   override def pendingFiberCount: Int = cacheGuardian.pendingFiberCount
 }
 
-class GuavaOapCache(cacheMemory: Long, cacheGuardianMemory: Long,
-    dataCacheUseRatio: Double) extends OapCache with Logging {
+class GuavaOapCache(
+    dataCacheMemory: Long,
+    indexCacheMemory: Long,
+    cacheGuardianMemory: Long)
+    extends OapCache with Logging {
 
   // TODO: CacheGuardian can also track cache statistics periodically
   private val cacheGuardian = new CacheGuardian(cacheGuardianMemory)
   cacheGuardian.start()
 
   private val KB: Double = 1024
-  private val MAX_WEIGHT = (cacheMemory / KB).toInt
-  private val DATA_MAX_WEIGHT = (cacheMemory * dataCacheUseRatio / KB).toInt
-  private val INDEX_MAX_WEIGHT = MAX_WEIGHT - DATA_MAX_WEIGHT
+  private val DATA_MAX_WEIGHT = (dataCacheMemory / KB).toInt
+  private val INDEX_MAX_WEIGHT = (indexCacheMemory / KB).toInt
   private val CONCURRENCY_LEVEL = 4
 
   // Total cached size for debug purpose, not include pending fiber

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -140,6 +140,25 @@ object OapConf {
       .stringConf
       .createWithDefault("offheap")
 
+  val OAP_MIXED_INDEX_MEMORY_MANAGER =
+    SqlConfAdapter.buildConf("spark.sql.oap.mixed.index.memory.manager")
+      .internal()
+      .doc("Sets the implement of index memory manager in mixed mode," +
+        "it only supports offheap(DRAM OFF_HEAP) and " +
+        "(PM) Intel Optane DC persistent memory currently.")
+      .stringConf
+      .createWithDefault("offheap")
+
+  val OAP_MIXED_DATA_MEMORY_MANAGER =
+    SqlConfAdapter.buildConf("spark.sql.oap.mixed.data.memory.manager")
+      .internal()
+      .doc("Sets the implement of data memory manager in mix mode," +
+        "it only supports offheap(DRAM OFF_HEAP) and " +
+        "(PM) Intel Optane DC persistent memory currently." +
+        "This is only available in mix mode")
+      .stringConf
+      .createWithDefault("offheap")
+
   val OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.config.file")
       .internal()

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -140,24 +140,24 @@ object OapConf {
       .stringConf
       .createWithDefault("offheap")
 
-  val OAP_MIXED_INDEX_MEMORY_MANAGER =
-    SqlConfAdapter.buildConf("spark.sql.oap.mixed.index.memory.manager")
+  val OAP_MIX_INDEX_MEMORY_MANAGER =
+    SqlConfAdapter.buildConf("spark.sql.oap.mix.index.memory.manager")
       .internal()
-      .doc("Sets the implement of index memory manager in mixed mode," +
+      .doc("Sets the implement of index memory manager in mix mode," +
         "it only supports offheap(DRAM OFF_HEAP) and " +
         "(PM) Intel Optane DC persistent memory currently.")
       .stringConf
       .createWithDefault("offheap")
 
-  val OAP_MIXED_DATA_MEMORY_MANAGER =
-    SqlConfAdapter.buildConf("spark.sql.oap.mixed.data.memory.manager")
+  val OAP_MIX_DATA_MEMORY_MANAGER =
+    SqlConfAdapter.buildConf("spark.sql.oap.mix.data.memory.manager")
       .internal()
       .doc("Sets the implement of data memory manager in mix mode," +
         "it only supports offheap(DRAM OFF_HEAP) and " +
         "(PM) Intel Optane DC persistent memory currently." +
         "This is only available in mix mode")
       .stringConf
-      .createWithDefault("offheap")
+      .createWithDefault("pm")
 
   val OAP_FIBERCACHE_PERSISTENT_MEMORY_CONFIG_FILE =
     SqlConfAdapter.buildConf("spark.sql.oap.fiberCache.persistent.memory.config.file")

--- a/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
+++ b/src/main/scala/org/apache/spark/sql/internal/oap/OapConf.scala
@@ -128,7 +128,8 @@ object OapConf {
   val OAP_DATAFIBER_USE_FIBERCACHE_RATIO =
     SqlConfAdapter.buildConf("spark.sql.oap.dataCache.use.fiberCache.ratio")
       .internal()
-      .doc("Define the ratio of data cache use fiber cache ratio.")
+      .doc("Define the ratio of data cache use fiber cache ratio. " +
+        "This is not available under mix mode")
       .doubleConf
       .createWithDefault(0.8)
 
@@ -145,7 +146,8 @@ object OapConf {
       .internal()
       .doc("Sets the implement of index memory manager in mix mode," +
         "it only supports offheap(DRAM OFF_HEAP) and " +
-        "(PM) Intel Optane DC persistent memory currently.")
+        "(PM) Intel Optane DC persistent memory currently." +
+        "It should be different from spark.sql.oap.mix.data.memory.manager")
       .stringConf
       .createWithDefault("offheap")
 
@@ -155,7 +157,7 @@ object OapConf {
       .doc("Sets the implement of data memory manager in mix mode," +
         "it only supports offheap(DRAM OFF_HEAP) and " +
         "(PM) Intel Optane DC persistent memory currently." +
-        "This is only available in mix mode")
+        "It should be different from spark.sql.oap.mix.index.memory.manager")
       .stringConf
       .createWithDefault("pm")
 

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/FiberCacheManagerSuite.scala
@@ -48,8 +48,8 @@ class FiberCacheManagerSuite extends SharedOapContext {
   private def dataCacheRatio =
     SparkEnv.get.conf.getDouble(OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.key,
       OapConf.OAP_DATAFIBER_USE_FIBERCACHE_RATIO.defaultValue.get)
-  private def dataCacheMemorySize = (memoryManager.cacheMemory * dataCacheRatio).toLong
-  private def indexCacheMemorySize = memoryManager.cacheMemory - dataCacheMemorySize
+  private def dataCacheMemorySize = memoryManager.dataCacheMemory
+  private def indexCacheMemorySize = memoryManager.indexCacheMemory
 
   test("unit test") {
     val dataMemorySizeInMB = (dataCacheMemorySize / mbSize).toInt

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/TestFiberCache.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/TestFiberCache.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 import org.apache.spark.sql.oap.OapRuntime
 
 class TestFiberCache(fiberCache: FiberCache)
-  extends FiberCache(fiberData = MemoryBlockHolder(null, fiberCache.getBaseOffset,
+  extends FiberCache(fiberData = DataMemoryBlockHolder(null, fiberCache.getBaseOffset,
       fiberCache.size(), fiberCache.getOccupiedSize())) {
 
   def free(): Unit = {

--- a/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/TestFiberCache.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/datasources/oap/filecache/TestFiberCache.scala
@@ -20,7 +20,8 @@ package org.apache.spark.sql.execution.datasources.oap.filecache
 import org.apache.spark.sql.oap.OapRuntime
 
 class TestFiberCache(fiberCache: FiberCache)
-  extends FiberCache(fiberData = DataMemoryBlockHolder(null, fiberCache.getBaseOffset,
+  extends FiberCache(fiberData =
+    MemoryBlockHolder(CacheEnum.GENERAL, null, fiberCache.getBaseOffset,
       fiberCache.size(), fiberCache.getOccupiedSize())) {
 
   def free(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement a MixMemoryManager to physically separate Index and Data Cache. 

In MixMemoryManager, dataManager and indexManager has to be different. Eg, if one is using OffHeapMemoryManager, the other has to use the PersistentMemoryManger. 
